### PR TITLE
Add config-based switching for web or desktop mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: venv Debug",
+            "name": "Python Debug Mode",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/desktop/app_window.py",
@@ -10,6 +10,37 @@
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/venv/bin/python"
             }
+        },
+        {
+            "name": "DesktopApp (web_debug mode)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/desktop/app_window.py",
+            "console": "integratedTerminal",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/venv/bin/python",
+                "APP_MODE": "web_debug"  // または config.json で mode: web_debug にする場合は不要
+            }
+        },
+        {
+            "name": "React: npm start",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/frontend",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "start"
+            ],
+            "console": "integratedTerminal"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Debug: Desktop + React (web_debug)",
+            "configurations": [
+                "React: npm start",
+                "DesktopApp (web_debug mode)"
+            ]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -90,3 +90,26 @@ python app_window.py
 
 Flow Production Tracking等の実API連携もdesktop/api_client.pyを拡張する形で実現可
 
+## Configuration
+
+`config.json` in the project root controls how the desktop backend and
+frontend connect during development and production.  Example:
+
+```json
+{
+  "mode": "desktop",          // "desktop" or "web_debug"
+  "react_url": "http://localhost:3000",
+  "build_path": "./frontend/build/index.html",
+  "webchannel_port": 12345
+}
+```
+
+A `.env.example` in `frontend/` shows how to set `REACT_APP_WEBCHANNEL_URL` for
+the dev server.
+
+- **desktop**: loads the built React assets into `QWebEngineView`.
+- **web_debug**: starts a WebSocket based `QWebChannel` on the given port and
+  opens `react_url` in your browser. The running dev server (`npm start`) should
+  specify the same port via `REACT_APP_WEBCHANNEL_URL` so the frontend can
+  connect to the backend.
+

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "mode": "desktop",
+  "react_url": "http://localhost:3000",
+  "build_path": "./frontend/build/index.html",
+  "webchannel_port": 12345
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "mode": "desktop",
+  "mode": "web_debug",
   "react_url": "http://localhost:3000",
   "build_path": "./frontend/build/index.html",
   "webchannel_port": 12345

--- a/desktop/app_config.py
+++ b/desktop/app_config.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+DEFAULT_CONFIG = {
+    "mode": "desktop",
+    "react_url": "http://localhost:3000",
+    "build_path": "./frontend/build/index.html",
+    "webchannel_port": 12345,
+}
+
+
+def load_config() -> dict:
+    """Load configuration from ../config.json if present."""
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    config_path = os.path.join(base_dir, "config.json")
+    config = DEFAULT_CONFIG.copy()
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                user_cfg = json.load(f)
+                if isinstance(user_cfg, dict):
+                    config.update(user_cfg)
+        except Exception as exc:  # pragma: no cover - simple load
+            print(f"Failed to load config: {exc}")
+    return config

--- a/desktop/app_window.py
+++ b/desktop/app_window.py
@@ -48,10 +48,7 @@ class AppWindow(QMainWindow):
         self.view.page().setWebChannel(self.channel)
 
         build_path = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                self.config.get("build_path", "../frontend/build/index.html"),
-            )
+            os.path.join(os.path.dirname(__file__), "../frontend/build/index.html")
         )
         self.view.load(QUrl.fromLocalFile(build_path))
 

--- a/desktop/app_window.py
+++ b/desktop/app_window.py
@@ -1,47 +1,87 @@
 import os
 import sys
+import webbrowser
 from PySide6.QtCore import QUrl
 from PySide6.QtWidgets import QApplication, QMainWindow
 from PySide6.QtWebEngineWidgets import QWebEngineView
-from PySide6.QtWebChannel import QWebChannel
 from PySide6.QtWebEngineCore import QWebEnginePage
+from PySide6.QtWebChannel import QWebChannel
+from PySide6.QtWebSockets import QWebSocketServer
+from PySide6.QtNetwork import QHostAddress
+
 from webchannel_bridge import DataBridge
+from websocket_transport import WebSocketTransport
+from app_config import load_config
 
 os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--enable-logging --log-level=0"
+
+
 class CustomWebEnginePage(QWebEnginePage):
     def javaScriptConsoleMessage(self, level, message, lineNumber, sourceID):
         level_map = {0: "Info", 1: "Warning", 2: "Error"}
         level_str = level_map.get(level, str(level))
         print(f"[JS:{level_str}] {message} (at {sourceID}:{lineNumber})")
-        
+
+
 class AppWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
+        self.config = load_config()
+        self.data_bridge = DataBridge()
+
+        mode = self.config.get("mode", "desktop")
+        if mode == "desktop":
+            self._init_desktop_mode()
+        else:
+            self._init_web_debug_mode()
+
+    # ----- desktop mode -----
+    def _init_desktop_mode(self) -> None:
         self.setWindowTitle("Desktop Gantt App (PySide6)")
         self.resize(1280, 720)
         self.view = QWebEngineView(self)
-
-        # カスタムページをセット
         self.view.setPage(CustomWebEnginePage(self.view))
         self.setCentralWidget(self.view)
 
-        # QWebChannelセットアップ
         self.channel = QWebChannel(self.view.page())
-        self.data_bridge = DataBridge()
         self.channel.registerObject("dataBridge", self.data_bridge)
         self.view.page().setWebChannel(self.channel)
 
-        # React build/index.htmlの絶対パスを取得
         build_path = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "../frontend/build/index.html")
+            os.path.join(
+                os.path.dirname(__file__),
+                self.config.get("build_path", "../frontend/build/index.html"),
+            )
         )
         self.view.load(QUrl.fromLocalFile(build_path))
 
-    def handle_js_console_message(self, level, message, lineNumber, sourceID):
-        print(f"[JS:{level}] {message} (at {sourceID}:{lineNumber})")
+    # ----- web debug mode -----
+    def _init_web_debug_mode(self) -> None:
+        port = int(self.config.get("webchannel_port", 12345))
+        self.server = QWebSocketServer("Backend", QWebSocketServer.NonSecureMode)
+        self.server.listen(QHostAddress.LocalHost, port)
+
+        self.channel = QWebChannel()
+        self.channel.registerObject("dataBridge", self.data_bridge)
+        self.server.newConnection.connect(self._on_new_connection)
+
+        react_url = self.config.get("react_url", "http://localhost:3000")
+        webbrowser.open(react_url)
+        print(
+            f"Web debug mode active. Listening on ws://localhost:{port} and opening {react_url}."
+        )
+
+    def _on_new_connection(self) -> None:
+        socket = self.server.nextPendingConnection()
+        if socket is None:
+            return
+        transport = WebSocketTransport(socket)
+        self.channel.connectTo(transport)
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     win = AppWindow()
-    win.show()
+    if win.config.get("mode", "desktop") == "desktop":
+        win.show()
     sys.exit(app.exec())

--- a/desktop/websocket_transport.py
+++ b/desktop/websocket_transport.py
@@ -1,0 +1,27 @@
+from PySide6.QtCore import QObject, Slot, Signal
+from PySide6.QtWebChannel import QWebChannelAbstractTransport
+from PySide6.QtWebSockets import QWebSocket
+
+
+class WebSocketTransport(QWebChannelAbstractTransport):
+    """Transport layer between QWebChannel and a QWebSocket."""
+
+    messageReceived = Signal(str)
+
+    def __init__(self, socket: QWebSocket):
+        super().__init__()
+        self._socket = socket
+        socket.textMessageReceived.connect(self.on_text_message)
+        socket.binaryMessageReceived.connect(self.on_binary_message)
+        socket.disconnected.connect(self.deleteLater)
+
+    @Slot(str)
+    def on_text_message(self, message: str) -> None:
+        self.messageReceived.emit(message)
+
+    @Slot(bytes)
+    def on_binary_message(self, message: bytes) -> None:
+        self.messageReceived.emit(bytes(message).decode("utf-8"))
+
+    def sendMessage(self, message: str) -> None:  # type: ignore[override]
+        self._socket.sendTextMessage(message)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# URL for QWebChannel WebSocket connection when running in web_debug mode
+REACT_APP_WEBCHANNEL_URL=ws://localhost:12345

--- a/frontend/src/Initializer.tsx
+++ b/frontend/src/Initializer.tsx
@@ -12,8 +12,10 @@ const fetchInitialData = async (
   setLoading: any
 ) => {
   setLoading(true);
+  console.log("Fetching initial data...");
   try {
     const result = await bridgeApi.fetchAll();
+    console.log("res",result);
     addSubprojects(result.subproject || []);
     addPhases(result.phases || []);
     addAssets(result.assets || []);

--- a/frontend/src/api/bridgeApi.ts
+++ b/frontend/src/api/bridgeApi.ts
@@ -8,13 +8,17 @@ function getBridge(): Promise<BridgeObject> {
   if (!bridgePromise) {
     bridgePromise = new Promise((resolve) => {
       const w = window as any;
-      const webChannelUrl = process.env.REACT_APP_WEBCHANNEL_URL;
+      const webChannelUrl = "ws://localhost:12345"
+      // process.env.REACT_APP_WEBCHANNEL_URL;
+      console.log("bridgePromise1",window)
       if (w.qt && w.qt.webChannelTransport) {
+        console.log("bridgePromise qt")
         new (w as any).QWebChannel(w.qt.webChannelTransport, (channel: any) => {
           resolve(channel.objects.dataBridge);
         });
       } else if (webChannelUrl) {
         const socket = new WebSocket(webChannelUrl);
+        console.log("bridgePromise2")
         socket.addEventListener("open", () => {
           new (w as any).QWebChannel(socket, (channel: any) => {
             resolve(channel.objects.dataBridge);
@@ -22,6 +26,7 @@ function getBridge(): Promise<BridgeObject> {
         });
       } else {
         // If not running inside the desktop shell, resolve to null
+        console.log("bridgePromise nll")
         resolve(null);
       }
     });

--- a/frontend/src/api/bridgeApi.ts
+++ b/frontend/src/api/bridgeApi.ts
@@ -8,9 +8,17 @@ function getBridge(): Promise<BridgeObject> {
   if (!bridgePromise) {
     bridgePromise = new Promise((resolve) => {
       const w = window as any;
+      const webChannelUrl = process.env.REACT_APP_WEBCHANNEL_URL;
       if (w.qt && w.qt.webChannelTransport) {
         new (w as any).QWebChannel(w.qt.webChannelTransport, (channel: any) => {
           resolve(channel.objects.dataBridge);
+        });
+      } else if (webChannelUrl) {
+        const socket = new WebSocket(webChannelUrl);
+        socket.addEventListener("open", () => {
+          new (w as any).QWebChannel(socket, (channel: any) => {
+            resolve(channel.objects.dataBridge);
+          });
         });
       } else {
         // If not running inside the desktop shell, resolve to null


### PR DESCRIPTION
## Summary
- allow running the desktop backend in `web_debug` or `desktop` mode
- add `config.json` with mode, React URL, build path and web channel port
- implement websocket-based QWebChannel server for debug mode
- update React bridge to connect via `REACT_APP_WEBCHANNEL_URL`
- document configuration and add example `.env`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_688a1ac5e2808331b683bb43327f332c