### PR TITLE
Ensure bridge API waits for channelReady

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,14 @@ the dev server.
   specify the same port via `REACT_APP_WEBCHANNEL_URL` so the frontend can
   connect to the backend.
 
+### WebChannel usage
+
+`bridgeApi.channelReady` resolves when the Qt `QWebChannel` and `dataBridge`
+object are available. Always await this promise before invoking any API
+method:
+
+```ts
+await bridgeApi.channelReady;
+const data = await bridgeApi.fetchAll();
+```
+

--- a/frontend/src/Initializer.tsx
+++ b/frontend/src/Initializer.tsx
@@ -41,15 +41,18 @@ const Initializer = () => {
   } = useAppContext();
 
   useEffect(() => {
-    fetchInitialData(
-      addSubprojects,
-      addPhases,
-      addAssets,
-      addTasks,
-      addWorkloads,
-      addPeople,
-      setLoading
-    );
+    (async () => {
+      await bridgeApi.channelReady;
+      await fetchInitialData(
+        addSubprojects,
+        addPhases,
+        addAssets,
+        addTasks,
+        addWorkloads,
+        addPeople,
+        setLoading
+      );
+    })();
     // eslint-disable-next-line
   }, []);
 


### PR DESCRIPTION
## Summary
- make bridge API expose `channelReady` and wait on it before calling Qt objects
- await `channelReady` in the Initializer so requests only fire once the WebChannel is up
- document the new promise-based pattern in the README

## Testing
- `npm run build`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b179d3dd4833195ef1d80435f4201