### PR TITLE
Fix WebChannel URL configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,10 @@
             "runtimeArgs": [
                 "start"
             ],
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "env": {
+                "REACT_APP_WEBCHANNEL_URL": "ws://localhost:12345"
+            }
         }
     ],
     "compounds": [

--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ frontend connect during development and production.  Example:
 }
 ```
 
-A `.env.example` in `frontend/` shows how to set `REACT_APP_WEBCHANNEL_URL` for
-the dev server.
+A `.env.example` in `frontend/` shows how to set `REACT_APP_WEBCHANNEL_URL` (or
+`REACT_APP_QT_WEBSOCKET_URL`) for the dev server. The frontend reads these
+variables to determine the WebSocket URL for the Qt `QWebChannel`.
 
 - **desktop**: loads the built React assets into `QWebEngineView`.
 - **web_debug**: starts a WebSocket based `QWebChannel` on the given port and
   opens `react_url` in your browser. The running dev server (`npm start`) should
-  specify the same port via `REACT_APP_WEBCHANNEL_URL` so the frontend can
-  connect to the backend.
+  specify the same port via `REACT_APP_WEBCHANNEL_URL` (or
+  `REACT_APP_QT_WEBSOCKET_URL`) so the frontend can connect to the backend.
 
 ### WebChannel usage
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,4 @@
 # URL for QWebChannel WebSocket connection when running in web_debug mode
+# Either variable will be read by bridgeApi.ts
 REACT_APP_WEBCHANNEL_URL=ws://localhost:12345
+REACT_APP_QT_WEBSOCKET_URL=

--- a/frontend/src/api/bridgeApi.ts
+++ b/frontend/src/api/bridgeApi.ts
@@ -15,11 +15,18 @@ export const channelReady: Promise<void> = new Promise((resolve) => {
   readyResolve = resolve;
 });
 
+// `REACT_APP_WEBCHANNEL_URL` or `REACT_APP_QT_WEBSOCKET_URL` can be defined at
+// build/runtime to point to the backend WebSocket. If not set, it defaults to
+// ws://localhost:12345 for development.
 function getBridge(): Promise<BridgeObject | null> {
   if (!bridgePromise) {
     bridgePromise = new Promise((resolve) => {
       const w = window as any;
-      const webChannelUrl = "ws://localhost:12345";
+      const envUrl =
+        process.env.REACT_APP_QT_WEBSOCKET_URL ||
+        process.env.REACT_APP_WEBCHANNEL_URL;
+      const webChannelUrl = envUrl || "ws://localhost:12345";
+      console.log(`Connecting to Qt WebChannel at: ${webChannelUrl}`);
       if (w.qt && w.qt.webChannelTransport) {
         new (w as any).QWebChannel(w.qt.webChannelTransport, (channel: any) => {
           readyResolve && readyResolve();


### PR DESCRIPTION
## Summary
- ensure the frontend always connects to the Python WebSocket on port 12345
- allow configuration via `REACT_APP_WEBCHANNEL_URL` or `REACT_APP_QT_WEBSOCKET_URL`
- log the WebSocket URL when connecting
- document environment variable usage
- set the environment variable in VSCode launch config

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c2a0689948331a07303cdbfec52a8