### PR TITLE
Improve WebChannel debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ frontend connect during development and production.  Example:
 A `.env.example` in `frontend/` shows how to set `REACT_APP_WEBCHANNEL_URL` for
 the dev server.
 
+The frontend loads `public/qtwebchannel.js` which should match the
+`qwebchannel.js` bundled with your installed PySide6 version. If the file is
+missing, copy it from `site-packages/PySide6/Qt/resources/qtwebchannel/`.
+
 - **desktop**: loads the built React assets into `QWebEngineView`.
 - **web_debug**: starts a WebSocket based `QWebChannel` on the given port and
   opens `react_url` in your browser. The running dev server (`npm start`) should

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,7 @@
+# Python
+# pycache
+__pycache__
+*.py[cod]  
+*.pyo
+*.pyd
+*.pyd

--- a/desktop/app_window.py
+++ b/desktop/app_window.py
@@ -47,6 +47,7 @@ class AppWindow(QMainWindow):
         self.channel = QWebChannel(self.view.page())
         self.channel.registerObject("dataBridge", self.data_bridge)
         self.view.page().setWebChannel(self.channel)
+        print("[QWebChannel] Objects:", self.channel.registeredObjects())
 
         build_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../frontend/build/index.html")
@@ -62,6 +63,7 @@ class AppWindow(QMainWindow):
         self.channel = QWebChannel()
         self.channel.registerObject("dataBridge", self.data_bridge)
         self.server.newConnection.connect(self._on_new_connection)
+        print("[QWebChannel] Objects:", self.channel.registeredObjects())
 
         react_url = self.config.get("react_url", "http://localhost:3000")
         webbrowser.open(react_url)
@@ -70,12 +72,31 @@ class AppWindow(QMainWindow):
         )
 
     def _on_new_connection(self) -> None:
+        # socket = self.server.nextPendingConnection()
+        # if socket is None:
+        #     return
+        # transport = WebSocketTransport(socket)
+        # self.transports.append(transport)
+        # print("[AppWindow] New WebSocket connection")
+        # self.channel.connectTo(transport)
+        # print("[DEBUG] connectTo() called for", transport)
+        # 既存のコネクションをクローズ＆クリーンアップ
+        for t in self.transports:
+            try:
+                t._socket.close()
+                t.deleteLater()
+            except Exception as e:
+                print("[DEBUG] cleanup error", e)
+        self.transports.clear()
+
+        # 新しいコネクションを受け付ける
         socket = self.server.nextPendingConnection()
         if socket is None:
             return
         transport = WebSocketTransport(socket)
         self.transports.append(transport)
         print("[AppWindow] New WebSocket connection")
+        print("[DEBUG] connectTo() called for", transport)
         self.channel.connectTo(transport)
 
 

--- a/desktop/app_window.py
+++ b/desktop/app_window.py
@@ -28,6 +28,7 @@ class AppWindow(QMainWindow):
         super().__init__()
         self.config = load_config()
         self.data_bridge = DataBridge()
+        self.transports = []
 
         mode = self.config.get("mode", "desktop")
         if mode == "desktop":
@@ -73,6 +74,8 @@ class AppWindow(QMainWindow):
         if socket is None:
             return
         transport = WebSocketTransport(socket)
+        self.transports.append(transport)
+        print("[AppWindow] New WebSocket connection")
         self.channel.connectTo(transport)
 
 

--- a/desktop/websocket_transport.py
+++ b/desktop/websocket_transport.py
@@ -28,4 +28,8 @@ class WebSocketTransport(QWebChannelAbstractTransport):
         self.messageReceived.emit(decoded)
 
     def sendMessage(self, message: str) -> None:  # type: ignore[override]
-        self._socket.sendTextMessage(message)
+        print("[WebSocketTransport] send message", message)
+        try:
+         self._socket.sendTextMessage(message)
+        except Exception as e:
+         print("[WebSocketTransport] sendMessage ERROR:", e)

--- a/desktop/websocket_transport.py
+++ b/desktop/websocket_transport.py
@@ -14,14 +14,18 @@ class WebSocketTransport(QWebChannelAbstractTransport):
         socket.textMessageReceived.connect(self.on_text_message)
         socket.binaryMessageReceived.connect(self.on_binary_message)
         socket.disconnected.connect(self.deleteLater)
+        print("[WebSocketTransport] new connection")
 
     @Slot(str)
     def on_text_message(self, message: str) -> None:
+        print("[WebSocketTransport] text message", message)
         self.messageReceived.emit(message)
 
     @Slot(bytes)
     def on_binary_message(self, message: bytes) -> None:
-        self.messageReceived.emit(bytes(message).decode("utf-8"))
+        decoded = bytes(message).decode("utf-8")
+        print("[WebSocketTransport] binary message", decoded)
+        self.messageReceived.emit(decoded)
 
     def sendMessage(self, message: str) -> None:  # type: ignore[override]
         self._socket.sendTextMessage(message)

--- a/dummy_server/.gitignore
+++ b/dummy_server/.gitignore
@@ -1,5 +1,5 @@
 # Python
-__pycache__/
+./__pycache__/
 *.py[cod]
 *.pyo
 *.pyd

--- a/frontend/public/qtwebchannel.js
+++ b/frontend/public/qtwebchannel.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2016 The Qt Company Ltd.
 // Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Milian Wolff <milian.wolff@kdab.com>
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+// Qt-Security score:critical reason:data-parser
 
 "use strict";
 

--- a/frontend/src/api/bridgeApi.ts
+++ b/frontend/src/api/bridgeApi.ts
@@ -13,6 +13,7 @@ let readyResolve: (() => void) | null = null;
  */
 export const channelReady: Promise<void> = new Promise((resolve) => {
   readyResolve = resolve;
+  getBridge()
 });
 
 function getBridge(): Promise<BridgeObject | null> {
@@ -65,6 +66,7 @@ async function callBridge(method: string, ...args: any[]): Promise<any> {
 }
 
 export function fetchAll() {
+  console.log("call fetchAll");
   return callBridge('fetchAll');
 }
 

--- a/frontend/src/api/bridgeApi.ts
+++ b/frontend/src/api/bridgeApi.ts
@@ -19,7 +19,8 @@ function getBridge(): Promise<BridgeObject | null> {
   if (!bridgePromise) {
     bridgePromise = new Promise((resolve) => {
       const w = window as any;
-      const webChannelUrl = "ws://localhost:12345";
+      const webChannelUrl =
+        process.env.REACT_APP_WEBCHANNEL_URL || "ws://localhost:12345";
       if (w.qt && w.qt.webChannelTransport) {
         new (w as any).QWebChannel(w.qt.webChannelTransport, (channel: any) => {
           readyResolve && readyResolve();
@@ -28,10 +29,21 @@ function getBridge(): Promise<BridgeObject | null> {
       } else if (webChannelUrl) {
         const socket = new WebSocket(webChannelUrl);
         socket.addEventListener("open", () => {
+          console.log("WebSocket opened", webChannelUrl);
           new (w as any).QWebChannel(socket, (channel: any) => {
+            console.log("QWebChannel initialized");
             readyResolve && readyResolve();
             resolve(channel.objects.dataBridge);
           });
+        });
+        socket.addEventListener("message", (ev) => {
+          console.log("WS message", ev.data);
+        });
+        socket.addEventListener("error", (err) => {
+          console.error("WebSocket error", err);
+        });
+        socket.addEventListener("close", () => {
+          console.log("WebSocket closed");
         });
       } else {
         // Not running inside the desktop shell


### PR DESCRIPTION
## Summary
- log received WebSocket messages
- keep transports alive in the app window
- log WebSocket activity in the frontend
- mention matching qwebchannel.js in README

## Testing
- `python desktop/app_window.py` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_688c56fea728833188e6d53893390052